### PR TITLE
Fix locate function

### DIFF
--- a/findi.py
+++ b/findi.py
@@ -44,6 +44,7 @@ class FindMyIPhone(object):
                 raise Exception("Unable to find location within '%s' seconds" % max_wait)
             time.sleep(5)
             self.update_devices()
+            device = self.devices[device_num]
 
         return {
             'latitude': device.latitude,


### PR DESCRIPTION
The locate function kept waiting for the device to update, but since update_devices recreates the self.devices list each time it runs, we need to refetch the device from the list.
